### PR TITLE
add support for target option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0]
+
+- add an option to allow the use of targeted resources using the `-target` flag
+
 ## [1.4.1]
 
 ### Fixed

--- a/test/test_args.py
+++ b/test/test_args.py
@@ -54,3 +54,7 @@ def test_var_args():
       ["-backend-config='a=1'", '-backend-config=\'b=["2"]\''])
   assert sorted(tftest.parse_args(tf_vars={'a': 1, 'b': '["2"]'})) == sorted(
       ['-var', 'b=["2"]', '-var', 'a=1'])
+
+def test_targets():
+  assert tftest.parse_args(targets=['one','two']) == sorted(
+      ['-target=one','-target=two'])

--- a/tftest.py
+++ b/tftest.py
@@ -49,7 +49,7 @@ class TerraformTestError(Exception):
   pass
 
 
-def parse_args(init_vars=None, tf_vars=None, **kw):
+def parse_args(init_vars=None, tf_vars=None, targets=None, **kw):
   """Convert method arguments for use in Terraform commands.
 
   Args:
@@ -89,6 +89,8 @@ def parse_args(init_vars=None, tf_vars=None, **kw):
     cmd_args += list(itertools.chain.from_iterable(
         ("-var", "{}={}".format(k, v)) for k, v in tf_vars.items()
     ))
+  if targets:
+    cmd_args += [("-target={}".format(t)) for t in targets]
   return cmd_args
 
 
@@ -307,10 +309,11 @@ class TerraformTest(object):
                           init_vars=init_vars)
     return self.execute_command('init', *cmd_args).out
 
-  def plan(self, input=False, color=False, refresh=True, tf_vars=None, output=False):
+  def plan(self, input=False, color=False, refresh=True, tf_vars=None, targets=None, output=False):
     "Run Terraform plan command, optionally returning parsed plan output."
     cmd_args = parse_args(input=input, color=color,
-                          refresh=refresh, tf_vars=tf_vars)
+                          refresh=refresh, tf_vars=tf_vars,
+                          targets=targets)
     if not output:
       return self.execute_command('plan', *cmd_args).out
     with tempfile.NamedTemporaryFile() as fp:
@@ -322,10 +325,11 @@ class TerraformTest(object):
     except json.JSONDecodeError as e:
       raise TerraformTestError('Error decoding plan output: {}'.format(e))
 
-  def apply(self, input=False, color=False, auto_approve=True, tf_vars=None):
+  def apply(self, input=False, color=False, auto_approve=True, tf_vars=None, targets=None):
     """Run Terraform apply command."""
     cmd_args = parse_args(input=input, color=color,
-                          auto_approve=auto_approve, tf_vars=tf_vars)
+                          auto_approve=auto_approve, tf_vars=tf_vars,
+                          targets=targets)
     return self.execute_command('apply', *cmd_args).out
 
   def output(self, name=None, color=False, json_format=True):
@@ -343,16 +347,16 @@ class TerraformTest(object):
         _LOGGER.warning('error decoding output: {}'.format(e))
     return output
 
-  def destroy(self, color=False, auto_approve=True, tf_vars=None):
+  def destroy(self, color=False, auto_approve=True, tf_vars=None, targets=None):
     """Run Terraform destroy command."""
-    cmd_args = parse_args(
-        color=color, auto_approve=auto_approve, tf_vars=tf_vars)
+    cmd_args = parse_args(color=color, auto_approve=auto_approve,
+                          tf_vars=tf_vars, targets=targets)
     return self.execute_command('destroy', *cmd_args).out
 
-  def refresh(self, color=False, lock=False, tf_vars=None):
+  def refresh(self, color=False, lock=False, tf_vars=None, targets=None):
     """Run Terraform refresh command."""
-    cmd_args = parse_args(
-        color=color, lock=lock, tf_vars=tf_vars)
+    cmd_args = parse_args(color=color, lock=lock,
+                          tf_vars=tf_vars, targets=targets)
     return self.execute_command('refresh', *cmd_args).out
 
   def state_pull(self):

--- a/tftest.py
+++ b/tftest.py
@@ -33,7 +33,7 @@ import subprocess
 import tempfile
 import weakref
 
-__version__ = '1.4.1'
+__version__ = '1.5.0'
 
 _LOGGER = logging.getLogger('tftest')
 


### PR DESCRIPTION
I have a use case where I cannot delete all resources on destroy. So that terraform behaves nicely I need to limit the resources when using the target option.

Hopefully this looks good to you, otherwise let me know if you want me to implement any more tests, etc.