### PR TITLE
Fix backend config escaping

### DIFF
--- a/tftest.py
+++ b/tftest.py
@@ -81,7 +81,7 @@ def parse_args(init_vars=None, tf_vars=None, targets=None, **kw):
   if kw.get('refresh') is False:
     cmd_args.append('-refresh=false')
   if isinstance(init_vars, dict):
-    cmd_args += ['-backend-config=\'{}={}\''.format(k, v)
+    cmd_args += ['-backend-config={}={}'.format(k, v)
                  for k, v in init_vars.items()]
   elif isinstance(init_vars, str):
     cmd_args += ['-backend-config', '{}'.format(init_vars)]


### PR DESCRIPTION
A quick fix for #17 
Maybe there is a better solution.
Didn't quite get the mechanics of the issue.