### PR TITLE
Don't fail when resource_changes key not present in output

### DIFF
--- a/test/fixtures/plan_no_resource_changes/main.tf
+++ b/test/fixtures/plan_no_resource_changes/main.tf
@@ -1,0 +1,3 @@
+output "just_an_output" {
+  value = "Hello, plan!"
+}

--- a/test/fixtures/plan_no_resource_changes/main.tf
+++ b/test/fixtures/plan_no_resource_changes/main.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 output "just_an_output" {
   value = "Hello, plan!"
 }

--- a/test/test_plan.py
+++ b/test/test_plan.py
@@ -73,3 +73,10 @@ def test_modules(plan_out):
 def test_child_modules(plan_out):
   mod = plan_out.modules['module.parent'].child_modules['module.child']
   assert mod.resources['eggs.someeggs']['values']['eggs-value'] == 'eggs'
+
+
+def test_plan_with_no_resources_succeeds(fixtures_dir):
+  tf = tftest.TerraformTest('plan_no_resource_changes', fixtures_dir)
+  result = tf.plan(output=True)
+
+  assert result.outputs['just_an_output'] == 'Hello, plan!'

--- a/tftest.py
+++ b/tftest.py
@@ -173,7 +173,7 @@ class TerraformPlanOutput(TerraformJSONBase):
         planned_values.get('root_module', {}))
     self.outputs = TerraformValueDict(planned_values.get('outputs', {}))
     self.resource_changes = dict((v['address'], v)
-                                 for v in self._raw['resource_changes'])
+                                 for v in self._raw.get('resource_changes', {}))
     # there might be no variables defined
     self.variables = TerraformValueDict(raw.get('variables', {}))
 


### PR DESCRIPTION
Fix for #26 tftest failed when terraform plan is empty