### PR TITLE
Windows fixes

### DIFF
--- a/test/test_files.py
+++ b/test/test_files.py
@@ -21,11 +21,14 @@ import tftest
 
 def test_setup_files():
   with tempfile.TemporaryDirectory() as tmpdir:
-    with tempfile.NamedTemporaryFile() as tmpfile:
-      tf = tftest.TerraformTest(tmpdir)
-      tf.setup(extra_files=[tmpfile.name])
-      assert os.path.exists(os.path.join(
+    try:
+      with tempfile.NamedTemporaryFile(delete=False) as tmpfile:
+        tf = tftest.TerraformTest(tmpdir)
+        tf.setup(extra_files=[tmpfile.name])
+        assert os.path.exists(os.path.join(
           tmpdir, os.path.basename(tmpfile.name)))
-      tf = None
-      assert not os.path.exists(os.path.join(
+        tf = None
+        assert not os.path.exists(os.path.join(
           tmpdir, os.path.basename(tmpfile.name)))
+    finally:
+      os.unlink(tmpfile.name)


### PR DESCRIPTION
master does not run on Windows (in general) for two reasons:

1. Windows is fussy about creating symlinks. You need to be running with admin privileges, or in Win 10 Developer Mode.
2. Temporary files are being created for Terraform to open (e.g. -out X) and the handles are being held on to by NamedTemporaryDirectory so it can delete the file later. Terraform on Windows does not like this, it wants exclusive access to the file (which is a Windows thing, not a Terraform thing as I understand it).

(1) is resolved by modifying TerraformTest to copy 'extra_files' if we detect we're running on Windows, track successfully copied files, and deleting them in the cleanup routine. This is made overly complex because the existing behaviour cleans up symlinked files that already existed but preserves not-symlinked-files. Since the Windows implementation is now copying files, we have to track successfully copied files separately. If the existing behaviour is in-fact a bug, and only those files symlinked by the setup routine should later be cleaned up, I can simplify the implementation further.

(2) is resolved by in one case by closing the temp files handle immediately, since we only really want a file name that Terraform can write output files to. In the other case, where we actually want the file to exist, so we tell NamedTemporaryDirectory not to track the file for deletion and handle that ourselves.