### PR TITLE
Fix double close on Windows 10

### DIFF
--- a/tftest.py
+++ b/tftest.py
@@ -553,7 +553,6 @@ class TerraformTest(object):
           _LOGGER.info(output.strip())
           full_output_lines.append(output)
       retcode = p.poll()
-      p.stdout.close()
       p.wait()
     except FileNotFoundError as e:
       raise TerraformTestError('Terraform executable not found: %s' % e)


### PR DESCRIPTION
Fix double close on Windows 10.0.19044 N/A Build 19044.

Exception in thread Thread-1:
Traceback (most recent call last):
  File "C:\Users\user\AppData\Local\Programs\Python\Python37\lib\threading.py", line 926, in _bootstrap_inner
    self.run()
  File "C:\Users\G000737\AppData\Local\Programs\Python\Python37\lib\threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\user\AppData\Local\Programs\Python\Python37\lib\subprocess.py", line 1267, in _readerthread
    buffer.append(fh.read())
ValueError: I/O operation on closed file.