### PR TITLE
add ability to pickle tftest instance objects

### DIFF
--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -20,40 +20,40 @@ import pickle
 
 
 def assert_pickle_flow(obj):
-	"""Ensures instance is the same after being pickled"""
-	pickled_obj = pickle.dumps(obj)
-	pickled_obj = pickle.loads(pickled_obj)
-	assert isinstance(pickled_obj, type(obj))
+  """Ensures instance is the same after being pickled"""
+  pickled_obj = pickle.dumps(obj)
+  pickled_obj = pickle.loads(pickled_obj)
+  assert isinstance(pickled_obj, type(obj))
 
 
 @pytest.fixture(scope="module")
 def tf(fixtures_dir):
-	tf = tftest.TerraformTest("plan_no_resource_changes", fixtures_dir)
-	tf.setup()
-	return tf
+  tf = tftest.TerraformTest("plan_no_resource_changes", fixtures_dir)
+  tf.setup()
+  return tf
 
 
 def test_setup(fixtures_dir):
-	tf = tftest.TerraformTest("plan_no_resource_changes", fixtures_dir)
-	expected = tf.setup()
-	assert_pickle_flow(expected)
+  tf = tftest.TerraformTest("plan_no_resource_changes", fixtures_dir)
+  expected = tf.setup()
+  assert_pickle_flow(expected)
 
 
 def test_plan(tf):
-	expected = tf.plan(output=True)
-	assert_pickle_flow(expected)
+  expected = tf.plan(output=True)
+  assert_pickle_flow(expected)
 
 
 def test_apply(tf):
-	expected = tf.apply()
-	assert_pickle_flow(expected)
+  expected = tf.apply()
+  assert_pickle_flow(expected)
 
 
 def test_output(tf):
-	expected = tf.output()
-	assert_pickle_flow(expected)
+  expected = tf.output()
+  assert_pickle_flow(expected)
 
 
 def test_state_pull(tf):
-	expected = tf.state_pull()
-	assert_pickle_flow(expected)
+  expected = tf.state_pull()
+  assert_pickle_flow(expected)

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -20,40 +20,40 @@ import pickle
 
 
 def assert_pickle_flow(obj):
-    """Ensures instance is the same after being pickled"""
-    pickled_obj = pickle.dumps(obj)
-    pickled_obj = pickle.loads(pickled_obj)
-    assert isinstance(pickled_obj, type(obj))
+	"""Ensures instance is the same after being pickled"""
+	pickled_obj = pickle.dumps(obj)
+	pickled_obj = pickle.loads(pickled_obj)
+	assert isinstance(pickled_obj, type(obj))
 
 
 @pytest.fixture(scope="module")
 def tf(fixtures_dir):
-    tf = tftest.TerraformTest("plan_no_resource_changes", fixtures_dir)
-    tf.setup()
-    return tf
+	tf = tftest.TerraformTest("plan_no_resource_changes", fixtures_dir)
+	tf.setup()
+	return tf
 
 
 def test_setup(fixtures_dir):
-    tf = tftest.TerraformTest("plan_no_resource_changes", fixtures_dir)
-    expected = tf.setup()
-    assert_pickle_flow(expected)
+	tf = tftest.TerraformTest("plan_no_resource_changes", fixtures_dir)
+	expected = tf.setup()
+	assert_pickle_flow(expected)
 
 
 def test_plan(tf):
-    expected = tf.plan(output=True)
-    assert_pickle_flow(expected)
+	expected = tf.plan(output=True)
+	assert_pickle_flow(expected)
 
 
 def test_apply(tf):
-    expected = tf.apply()
-    assert_pickle_flow(expected)
+	expected = tf.apply()
+	assert_pickle_flow(expected)
 
 
 def test_output(tf):
-    expected = tf.output()
-    assert_pickle_flow(expected)
+	expected = tf.output()
+	assert_pickle_flow(expected)
 
 
 def test_state_pull(tf):
-    expected = tf.state_pull()
-    assert_pickle_flow(expected)
+	expected = tf.state_pull()
+	assert_pickle_flow(expected)

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -1,0 +1,59 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"Test serialization of tftest instances"
+
+import pytest
+import tftest
+import pickle
+
+
+def assert_pickle_flow(obj):
+    """Ensures instance is the same after being pickled"""
+    pickled_obj = pickle.dumps(obj)
+    pickled_obj = pickle.loads(pickled_obj)
+    assert isinstance(pickled_obj, type(obj))
+
+
+@pytest.fixture(scope="module")
+def tf(fixtures_dir):
+    tf = tftest.TerraformTest("plan_no_resource_changes", fixtures_dir)
+    tf.setup()
+    return tf
+
+
+def test_setup(fixtures_dir):
+    tf = tftest.TerraformTest("plan_no_resource_changes", fixtures_dir)
+    expected = tf.setup()
+    assert_pickle_flow(expected)
+
+
+def test_plan(tf):
+    expected = tf.plan(output=True)
+    assert_pickle_flow(expected)
+
+
+def test_apply(tf):
+    expected = tf.apply()
+    assert_pickle_flow(expected)
+
+
+def test_output(tf):
+    expected = tf.output()
+    assert_pickle_flow(expected)
+
+
+def test_state_pull(tf):
+    expected = tf.state_pull()
+    assert_pickle_flow(expected)

--- a/tftest.py
+++ b/tftest.py
@@ -175,8 +175,8 @@ class TerraformValueDict(TerraformJSONBase):
 
   def __getattr__(self, name):
     if isinstance(name, str) and name[:2] == name[-2:] == '__':
-        # skip non-existing dunder method lookups
-        raise AttributeError(name)
+      # skip non-existing dunder method lookups
+      raise AttributeError(name)
     return getattr(self._raw, name)
 
   def __getitem__(self, name):
@@ -243,12 +243,12 @@ class TerraformPlanOutput(TerraformJSONBase):
 
   def __getattr__(self, name):
     return self._raw[name]
-  
+
   def __getstate__(self):
     return self.__dict__
 
   def __setstate__(self, d):
-      self.__dict__.update(d)
+    self.__dict__.update(d)
 
 
 class TerraformState(TerraformJSONBase):
@@ -272,12 +272,12 @@ class TerraformState(TerraformJSONBase):
 
   def __getattr__(self, name):
     return self._raw[name]
-  
+
   def __getstate__(self):
     return self.__dict__
 
   def __setstate__(self, d):
-      self.__dict__.update(d)
+    self.__dict__.update(d)
 
 
 class TerraformTest(object):

--- a/tftest.py
+++ b/tftest.py
@@ -174,6 +174,9 @@ class TerraformValueDict(TerraformJSONBase):
     self.sensitive = tuple(k for k, v in raw.items() if v.get('sensitive'))
 
   def __getattr__(self, name):
+    if isinstance(name, str) and name[:2] == name[-2:] == '__':
+        # skip non-existing dunder method lookups
+        raise AttributeError(name)
     return getattr(self._raw, name)
 
   def __getitem__(self, name):
@@ -240,6 +243,12 @@ class TerraformPlanOutput(TerraformJSONBase):
 
   def __getattr__(self, name):
     return self._raw[name]
+  
+  def __getstate__(self):
+    return self.__dict__
+
+  def __setstate__(self, d):
+      self.__dict__.update(d)
 
 
 class TerraformState(TerraformJSONBase):
@@ -263,6 +272,12 @@ class TerraformState(TerraformJSONBase):
 
   def __getattr__(self, name):
     return self._raw[name]
+  
+  def __getstate__(self):
+    return self.__dict__
+
+  def __setstate__(self, d):
+      self.__dict__.update(d)
 
 
 class TerraformTest(object):


### PR DESCRIPTION
The changes introduced allow `tftest.TerraformPlanOutput` and `tftest.TerraformState` instances to be [pickled](https://docs.python.org/3/library/pickle.html#pickle.Pickler). Given the above classes have custom `__getattr__` methods, the classes need `__getstate__` and `__setstate__` methods in order for `pickle.dumps()` to properly serialize the instances. In addition, in order for the serialized objects to be deserialized, the `TerraformValueDict.__getattr__` method needs to skip looking up dunder methods during `pickle.loads()` or else the method keeps calling itself resulting in a recursive loop.

If you're wondering what the use case of this functionality is, I'm currently creating caching fixtures for the outputs of tftest methods so that the output is available between pytest sessions. If it all goes well and it seems like a good fit for tftest, I may propose adding these fixtures to the tftest package within another PR.