### PR TITLE
Create cache hash after command

### DIFF
--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -70,10 +70,6 @@ def test_use_cache(tf):
     ),
 ], indirect=True)
 def test_no_use_cache(tf):
-  """
-  Ensures cache is not used and runs the execute_command() for every call of
-  the method
-  """
   expected_call_count = 2
   for method in cache_methods:
     with patch.object(tf, 'execute_command', wraps=tf.execute_command) as mock_execute_command:
@@ -84,6 +80,10 @@ def test_no_use_cache(tf):
 
 @pytest.mark.parametrize("tf", [True], indirect=True)
 def test_use_cache_with_same_tf_var_file(tf, tmp_path):
+  """
+  Ensures cache is used if the same tf_var_file argument is passed
+  within subsequent method calls
+  """
   tf_var_file_methods = ["plan", "apply", "destroy"]
 
   tf_vars_file = tmp_path / (str(uuid.uuid4()) + '.json')
@@ -99,6 +99,10 @@ def test_use_cache_with_same_tf_var_file(tf, tmp_path):
 
 @pytest.mark.parametrize("tf", [True], indirect=True)
 def test_use_cache_with_new_tf_var_file(tf, tmp_path):
+  """
+  Ensures cache is not used if a different tf_var_file argument is passed
+  within subsequent method calls
+  """
   tf_var_file_methods = ["plan", "apply", "destroy"]
   expected_call_count = 2
 
@@ -116,6 +120,10 @@ def test_use_cache_with_new_tf_var_file(tf, tmp_path):
 
 @pytest.mark.parametrize("tf", [True], indirect=True)
 def test_use_cache_with_new_extra_files(tf, tmp_path):
+  """
+  Ensures cache is not used if a different extra_files argument is passed
+  within subsequent method calls
+  """
   expected_call_count = 2
   tf_vars_file = tmp_path / (str(uuid.uuid4()) + '.json')
   tf_vars_file.write_text(json.dumps({"foo": "old"}))
@@ -130,6 +138,10 @@ def test_use_cache_with_new_extra_files(tf, tmp_path):
 
 @pytest.mark.parametrize("tf", [True], indirect=True)
 def test_use_cache_with_same_extra_files(tf, tmp_path):
+  """
+  Ensures cache is used if the same extra_files argument is passed
+  within subsequent method calls
+  """
   tf_vars_file = tmp_path / (str(uuid.uuid4()) + '.json')
   tf_vars_file.write_text(json.dumps({"foo": "old"}))
 
@@ -142,6 +154,10 @@ def test_use_cache_with_same_extra_files(tf, tmp_path):
 
 @pytest.mark.parametrize("tf", [True], indirect=True)
 def test_use_cache_with_new_env(tf):
+  """
+  Ensures cache is not used if the env attribute is updated
+  before subsequent method calls
+  """
   expected_call_count = 2
   for method in cache_methods:
     with patch.object(tf, 'execute_command', wraps=tf.execute_command) as mock_execute_command:
@@ -167,6 +183,10 @@ def dummy_tf_filepath(tf):
 
 @pytest.mark.parametrize("tf", [True], indirect=True)
 def test_use_cache_with_new_tf_content(tf, dummy_tf_filepath):
+  """
+  Ensures cache is not used if the tfdir directory is updated
+  before subsequent method calls
+  """
   expected_call_count = 2
   for method in cache_methods:
     with patch.object(tf, 'execute_command', wraps=tf.execute_command) as mock_execute_command:

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -26,12 +26,12 @@ pytest_plugins = [
 ]
 
 _LOGGER = logging.getLogger('tftest')
-
+_LOGGER.setLevel(logging.DEBUG)
 cache_methods = ["setup", "init", "plan", "apply", "output", "destroy"]
 
 
-@pytest.fixture
-def tf(request, fixtures_dir):
+@pytest.fixture(params=[True, False], ids=["enabled", "disabled"])
+def tf_cache_toggled(request, fixtures_dir):
   terra = tftest.TerraformTest(
       tfdir='plan_no_resource_changes',
       basedir=fixtures_dir,
@@ -46,7 +46,47 @@ def tf(request, fixtures_dir):
     _LOGGER.debug("%s does not exists", terra.cache_dir)
 
 
-@pytest.mark.parametrize("tf", [True], indirect=True)
+def test_no_use_cache(tf_cache_toggled):
+  """
+  Ensures cache is not used and runs the execute_command() for every call of
+  the method
+  """
+  expected_call_count = 2
+  for method in cache_methods:
+    with patch.object(tf_cache_toggled, 'execute_command', wraps=tf_cache_toggled.execute_command) as mock_execute_command:
+      for _ in range(expected_call_count):
+        getattr(tf_cache_toggled, method)(use_cache=False)
+      assert mock_execute_command.call_count == expected_call_count
+
+
+@pytest.fixture(params=[
+    {
+        "tfdir": "plan_no_resource_changes",
+        "binary": "terraform"
+    },
+    {
+        "tfdir": "tg_apply_all",
+        "binary": "terragrunt"
+    }
+], ids=["terraform", "terragrunt"])
+def tf(request, fixtures_dir):
+  terra = tftest.TerraformTest(
+      basedir=fixtures_dir,
+      enable_cache=True,
+      **request.param
+  )
+
+  yield terra
+
+  terra._cleanup(terra.tfdir, filenames=[], deep=True)
+
+  _LOGGER.debug("Removing cache dir")
+  try:
+    shutil.rmtree(terra.cache_dir)
+  except FileNotFoundError:
+    _LOGGER.debug("%s does not exists", terra.cache_dir)
+
+
 def test_use_cache(tf):
   """
   Ensures cache is used and runs the execute_command() for first call of the 
@@ -59,31 +99,11 @@ def test_use_cache(tf):
       assert mock_execute_command.call_count == 1
 
 
-@pytest.mark.parametrize("tf", [
-    pytest.param(
-        True,
-        id="enable_cache"
-    ),
-    pytest.param(
-        False,
-        id="disable_cache"
-    ),
-], indirect=True)
-def test_no_use_cache(tf):
-  """
-  Ensures cache is not used and runs the execute_command() for every call of
-  the method
-  """
-  expected_call_count = 2
-  for method in cache_methods:
-    with patch.object(tf, 'execute_command', wraps=tf.execute_command) as mock_execute_command:
-      for _ in range(expected_call_count):
-        getattr(tf, method)(use_cache=False)
-      assert mock_execute_command.call_count == expected_call_count
-
-
-@pytest.mark.parametrize("tf", [True], indirect=True)
 def test_use_cache_with_same_tf_var_file(tf, tmp_path):
+  """
+  Ensures cache is used if the same tf_var_file argument is passed
+  within subsequent method calls
+  """
   tf_var_file_methods = ["plan", "apply", "destroy"]
 
   tf_vars_file = tmp_path / (str(uuid.uuid4()) + '.json')
@@ -97,8 +117,11 @@ def test_use_cache_with_same_tf_var_file(tf, tmp_path):
     assert mock_execute_command.call_count == 1
 
 
-@pytest.mark.parametrize("tf", [True], indirect=True)
 def test_use_cache_with_new_tf_var_file(tf, tmp_path):
+  """
+  Ensures cache is not used if a different tf_var_file argument is passed
+  within subsequent method calls
+  """
   tf_var_file_methods = ["plan", "apply", "destroy"]
   expected_call_count = 2
 
@@ -114,34 +137,45 @@ def test_use_cache_with_new_tf_var_file(tf, tmp_path):
     assert mock_execute_command.call_count == expected_call_count
 
 
-@pytest.mark.parametrize("tf", [True], indirect=True)
 def test_use_cache_with_new_extra_files(tf, tmp_path):
+  """
+  Ensures cache is not used if a different extra_files argument is passed
+  within subsequent method calls
+  """
   expected_call_count = 2
   tf_vars_file = tmp_path / (str(uuid.uuid4()) + '.json')
   tf_vars_file.write_text(json.dumps({"foo": "old"}))
 
   with patch.object(tf, 'execute_command', wraps=tf.execute_command) as mock_execute_command:
     for _ in range(expected_call_count):
-      tf.setup(use_cache=True, extra_files=[tf_vars_file])
+      tf.setup(cleanup_on_exit=True, use_cache=True,
+               extra_files=[tf_vars_file])
       tf_vars_file.write_text(json.dumps({"foo": "new"}))
 
     assert mock_execute_command.call_count == expected_call_count
 
 
-@pytest.mark.parametrize("tf", [True], indirect=True)
 def test_use_cache_with_same_extra_files(tf, tmp_path):
+  """
+  Ensures cache is used if the same extra_files argument is passed
+  within subsequent method calls
+  """
   tf_vars_file = tmp_path / (str(uuid.uuid4()) + '.json')
   tf_vars_file.write_text(json.dumps({"foo": "old"}))
 
   with patch.object(tf, 'execute_command', wraps=tf.execute_command) as mock_execute_command:
     for _ in range(2):
-      tf.setup(use_cache=True, extra_files=[tf_vars_file])
+      tf.setup(cleanup_on_exit=True, use_cache=True,
+               extra_files=[tf_vars_file])
 
     assert mock_execute_command.call_count == 1
 
 
-@pytest.mark.parametrize("tf", [True], indirect=True)
 def test_use_cache_with_new_env(tf):
+  """
+  Ensures cache is not used if the env attribute is updated
+  before subsequent method calls
+  """
   expected_call_count = 2
   for method in cache_methods:
     with patch.object(tf, 'execute_command', wraps=tf.execute_command) as mock_execute_command:
@@ -165,8 +199,11 @@ def dummy_tf_filepath(tf):
   os.remove(filepath)
 
 
-@pytest.mark.parametrize("tf", [True], indirect=True)
 def test_use_cache_with_new_tf_content(tf, dummy_tf_filepath):
+  """
+  Ensures cache is not used if the tfdir directory is updated
+  before subsequent method calls
+  """
   expected_call_count = 2
   for method in cache_methods:
     with patch.object(tf, 'execute_command', wraps=tf.execute_command) as mock_execute_command:


### PR DESCRIPTION
The current implementation creates the cache hash value before running the terraform or terragrunt command. If the command creates any files within the `tfdir` directory then the cache will not be used for the subsequent call since the hash value is dependent on the contents of the `tfdir`. This is seen for example with the `terragrunt init` command that produces a `.terragrunt-cache` directory. To ensure that this directory is considered for the hash, the hash is now generated also after the command is executed.