### PR TITLE
[feature] added support to pass a complex dict

### DIFF
--- a/test/test_args.py
+++ b/test/test_args.py
@@ -47,11 +47,21 @@ ARGS_TESTS = (
     ({'tf_var_file': 'foo.tfvar'}, ['-var-file=foo.tfvar']),
     ({'tf_var_file': ['foo.tfvar', 'bar.tfvar']}, [
      '-var-file=foo.tfvar', '-var-file=bar.tfvar']),
+    ({'tf_vars': {'text':'text'}}, ['-var', 'text=text']),
+    ({'tf_vars': {'number': 0}}, ['-var', 'number=0']),
+    ({'tf_vars': {'bool': False}}, ['-var', 'bool=False']),
+    ({'tf_vars': {'dict': {'text':'text'}}}, 
+     ['-var', 'dict={"text": "text"}']),
+    ({'tf_vars': {'list': ['item1', 'item2']}}, 
+     ['-var', 'list=["item1", "item2"]']),
+    ({'tf_vars': {'dict': {'list':['item1','item2']}}}, 
+     ['-var', 'dict={"list": ["item1", "item2"]}']),
 )
 
 
 @pytest.mark.parametrize("kwargs, expected", ARGS_TESTS)
 def test_args(kwargs, expected):
+  print(tftest.parse_args())
   assert tftest.parse_args() == []
   assert tftest.parse_args(**kwargs) == expected
 

--- a/test/test_args.py
+++ b/test/test_args.py
@@ -47,14 +47,14 @@ ARGS_TESTS = (
     ({'tf_var_file': 'foo.tfvar'}, ['-var-file=foo.tfvar']),
     ({'tf_var_file': ['foo.tfvar', 'bar.tfvar']}, [
      '-var-file=foo.tfvar', '-var-file=bar.tfvar']),
-    ({'tf_vars': {'text':'text'}}, ['-var', 'text=text']),
+    ({'tf_vars': {'text': 'text'}}, ['-var', 'text=text']),
     ({'tf_vars': {'number': 0}}, ['-var', 'number=0']),
     ({'tf_vars': {'bool': False}}, ['-var', 'bool=False']),
-    ({'tf_vars': {'dict': {'text':'text'}}}, 
+    ({'tf_vars': {'dict': {'text': 'text'}}},
      ['-var', 'dict={"text": "text"}']),
-    ({'tf_vars': {'list': ['item1', 'item2']}}, 
+    ({'tf_vars': {'list': ['item1', 'item2']}},
      ['-var', 'list=["item1", "item2"]']),
-    ({'tf_vars': {'dict': {'list':['item1','item2']}}}, 
+    ({'tf_vars': {'dict': {'list': ['item1', 'item2']}}},
      ['-var', 'dict={"list": ["item1", "item2"]}']),
 )
 

--- a/test/test_args.py
+++ b/test/test_args.py
@@ -61,7 +61,6 @@ ARGS_TESTS = (
 
 @pytest.mark.parametrize("kwargs, expected", ARGS_TESTS)
 def test_args(kwargs, expected):
-  print(tftest.parse_args())
   assert tftest.parse_args() == []
   assert tftest.parse_args(**kwargs) == expected
 

--- a/tftest.py
+++ b/tftest.py
@@ -145,8 +145,9 @@ def parse_args(init_vars=None, tf_vars=None, targets=None, **kw):
     cmd_args += ['-backend-config', '{}'.format(init_vars)]
   if tf_vars:
     cmd_args += list(
-        itertools.chain.from_iterable(
-            ("-var", "{}={}".format(k, v)) for k, v in tf_vars.items()))
+      itertools.chain.from_iterable(
+        ("-var", "{}={}".format(k, json.dumps(v) if isinstance(v, (dict, list)) else v)) for k, v in tf_vars.items()
+    ))
   if targets:
     cmd_args += [("-target={}".format(t)) for t in targets]
   if kw.get('tf_var_file'):

--- a/tftest.py
+++ b/tftest.py
@@ -146,7 +146,9 @@ def parse_args(init_vars=None, tf_vars=None, targets=None, **kw):
   if tf_vars:
     cmd_args += list(
       itertools.chain.from_iterable(
-        ("-var", "{}={}".format(k, json.dumps(v) if isinstance(v, (dict, list)) else v)) for k, v in tf_vars.items()
+        ("-var", 
+         "{}={}".format(k, json.dumps(v) if isinstance(v, (dict, list)) else v))
+           for k, v in tf_vars.items()
     ))
   if targets:
     cmd_args += [("-target={}".format(t)) for t in targets]

--- a/tftest.py
+++ b/tftest.py
@@ -145,11 +145,11 @@ def parse_args(init_vars=None, tf_vars=None, targets=None, **kw):
     cmd_args += ['-backend-config', '{}'.format(init_vars)]
   if tf_vars:
     cmd_args += list(
-      itertools.chain.from_iterable(
-        ("-var", 
-         "{}={}".format(k, json.dumps(v) if isinstance(v, (dict, list)) else v))
-           for k, v in tf_vars.items()
-    ))
+        itertools.chain.from_iterable(
+            ("-var",
+             "{}={}".format(k, json.dumps(v) if isinstance(v, (dict, list)) else v))
+            for k, v in tf_vars.items()
+        ))
   if targets:
     cmd_args += [("-target={}".format(t)) for t in targets]
   if kw.get('tf_var_file'):


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/terraform-python-testing-helper/issues/68

added support to pass a complex dict to the tf_vars parameter

Like that:
`tf_vars = { "pep_spec": { "pep1": "test", "list": [ "item1", "item2" ] }, "list2": [ "item1", "item2" ] }`
