### PR TITLE
Make cache directory path Windows friendly

### DIFF
--- a/tftest.py
+++ b/tftest.py
@@ -386,7 +386,8 @@ class TerraformTest(object):
     """Returns hash of directory's file contents"""
     assert Path(directory).is_dir()
     try:
-      dir_iter = sorted(Path(directory).iterdir(), key=lambda p: str(p).lower())
+      dir_iter = sorted(Path(directory).iterdir(), 
+                        key=lambda p: str(p).lower())
     except FileNotFoundError:
       return hash
     for path in dir_iter:
@@ -433,7 +434,7 @@ class TerraformTest(object):
     params["tfdir"] = self._dirhash(self.tfdir, sha1(), ignore_hidden=True,
                                     exclude_directories=[".terraform"],
                                     excluded_extensions=['.backup', '.tfstate'
-                                                        ]).hexdigest()
+                                                         ]).hexdigest()
 
     return sha1(
         json.dumps(params, sort_keys=True,

--- a/tftest.py
+++ b/tftest.py
@@ -386,7 +386,7 @@ class TerraformTest(object):
     """Returns hash of directory's file contents"""
     assert Path(directory).is_dir()
     try:
-      dir_iter = sorted(Path(directory).iterdir(), 
+      dir_iter = sorted(Path(directory).iterdir(),
                         key=lambda p: str(p).lower())
     except FileNotFoundError:
       return hash

--- a/tftest.py
+++ b/tftest.py
@@ -458,7 +458,7 @@ class TerraformTest(object):
         return func(self, **kwargs)
 
       cache_dir = self.cache_dir / \
-          Path(self.tfdir.strip("/")) / Path(func.__name__)
+          Path(sha1(self.tfdir.encode("cp037")).hexdigest()) / Path(func.__name__)
       cache_dir.mkdir(parents=True, exist_ok=True)
 
       hash_filename = self.generate_cache_hash(kwargs)


### PR DESCRIPTION
The existing logic for building the cache directory path assumes *nix style paths when attempting to make a unique cache dir for each test fixture and step. Paths with a Windows drive prefix on the front ("C:\\...") muck this up. Pathlib's '/' operator silently covers this up (under Python 3.9 on Windows, at least).

This change _reasonably_ preserves the uniqueness logic whilst being Window friendly by taking a hash of the path to the test fixture's configuration directory `tfdir` and using that in the cache directory path construction.