### PR TITLE
Stop Windows hangs when last output is on stderr

### DIFF
--- a/tftest.py
+++ b/tftest.py
@@ -386,7 +386,8 @@ class TerraformTest(object):
     """Returns hash of directory's file contents"""
     assert Path(directory).is_dir()
     try:
-      dir_iter = sorted(Path(directory).iterdir(), key=lambda p: str(p).lower())
+      dir_iter = sorted(Path(directory).iterdir(), 
+                        key=lambda p: str(p).lower())
     except FileNotFoundError:
       return hash
     for path in dir_iter:
@@ -433,7 +434,7 @@ class TerraformTest(object):
     params["tfdir"] = self._dirhash(self.tfdir, sha1(), ignore_hidden=True,
                                     exclude_directories=[".terraform"],
                                     excluded_extensions=['.backup', '.tfstate'
-                                                        ]).hexdigest()
+                                                         ]).hexdigest()
 
     return sha1(
         json.dumps(params, sort_keys=True,

--- a/tftest.py
+++ b/tftest.py
@@ -386,7 +386,7 @@ class TerraformTest(object):
     """Returns hash of directory's file contents"""
     assert Path(directory).is_dir()
     try:
-      dir_iter = sorted(Path(directory).iterdir(), 
+      dir_iter = sorted(Path(directory).iterdir(),
                         key=lambda p: str(p).lower())
     except FileNotFoundError:
       return hash

--- a/tftest.py
+++ b/tftest.py
@@ -705,7 +705,7 @@ class TerraformTest(object):
     retcode = None
     full_output_lines = []
     try:
-      stderr_mode = subprocess.STDOUT if os.name = 'nt' else subprocess.PIPE
+      stderr_mode = subprocess.STDOUT if os.name == 'nt' else subprocess.PIPE
       p = subprocess.Popen(cmdline, stdout=subprocess.PIPE,
                            stderr=stderr_mode, cwd=self.tfdir, env=self.env,
                            universal_newlines=True, encoding='utf-8',

--- a/tftest.py
+++ b/tftest.py
@@ -705,8 +705,9 @@ class TerraformTest(object):
     retcode = None
     full_output_lines = []
     try:
+      stderr_mode = subprocess.STDOUT if os.name = 'nt' else subprocess.PIPE
       p = subprocess.Popen(cmdline, stdout=subprocess.PIPE,
-                           stderr=subprocess.PIPE, cwd=self.tfdir, env=self.env,
+                           stderr=stderr_mode, cwd=self.tfdir, env=self.env,
                            universal_newlines=True, encoding='utf-8',
                            errors='ignore')
       while True:


### PR DESCRIPTION
Terraform CLI runs sometimes only produce output on stderr, or writes its final output to stderr. Tests for variable validation conditions and pre/post conditions often elicit this behaviour. On Windows 10 and Python 3.9, this leads to a hang. Line 714 (in this PR) is a blocking operation that will never be satisfied given no further standard output will be observed.

This PR hacks around it when running on Windows by redirecting stderr to stdout. This truly is a hack, because later logic from line 724 onwards assumes `err` will contain stderr but will now always be empty. In practice, this seems to work on Windows OK.

A better solution might be to do something like https://stackoverflow.com/a/4896288. This pushes my limited python-fu.