### PR TITLE
Clean up terraform runtime files

### DIFF
--- a/test/fixtures/apply/main.tf
+++ b/test/fixtures/apply/main.tf
@@ -14,18 +14,10 @@
  * limitations under the License.
  */
 
-data "template_file" "sample" {
-  for_each = toset(var.names)
-  template = "sample template $${name}"
-  vars = {
-    name = each.key
-  }
-}
-
 resource "null_resource" "sample" {
   for_each = toset(var.names)
   triggers = {
     name     = each.key
-    template = data.template_file.sample[each.key].rendered
+    template = templatefile("${path.module}/template.tftpl", { name = each.key })
   }
 }

--- a/test/fixtures/apply/template.tftpl
+++ b/test/fixtures/apply/template.tftpl
@@ -1,0 +1,1 @@
+sample template ${name}

--- a/tftest.py
+++ b/tftest.py
@@ -365,9 +365,15 @@ class TerraformTest(object):
     path = os.path.join(tfdir, '.terraform')
     if os.path.isdir(path):
       shutil.rmtree(path, onerror=remove_readonly)
+    path = os.path.join(tfdir, '.terraform.lock.hcl')
+    if os.path.isfile(path):
+      os.unlink(path)
     path = os.path.join(tfdir, 'terraform.tfstate')
     if os.path.isfile(path):
       os.unlink(path)
+    for path in glob.glob(os.path.join(tfdir, 'terraform.tfstate.backup*')):
+      if os.path.isfile(path):
+        os.unlink(path)
     path = os.path.join(tfdir, '**', '.terragrunt-cache*')
     for tg_dir in glob.glob(path, recursive=True):
       if os.path.isdir(tg_dir):


### PR DESCRIPTION
Replace deprecated template_file datasource from template provider with templatefile built-in function in pytest fixture.