### PR TITLE
Fix: preserve absolute Path object for tfdir

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Publish to PyPI
 
 on:

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,7 @@
+# Gemini CLI Instructions for terraform-python-testing-helper
+
+- **Git Workflow:** Never use `git commit --amend`. Always create a new commit and push to the same branch to update an existing Pull Request.
+- **File Editing:** Always use the `replace` tool (or `write_file` for new files) for file edits. Do NOT use shell heredocs (`cat << 'EOF'`) or inline Python scripts to modify files.
+- **Copyright Boilerplate:** All new files must include the Apache 2.0 license boilerplate at the top. Ensure the copyright year is current (e.g., 2026).
+- **Linting:** Always run the project's linters before committing changes. Specifically, check formatting with `yapf --diff --recursive --parallel *.py test` and verify license headers with `python3 .github/workflows/scripts/check_boilerplate.py .`.
+- **Regressions & Testing:** When fixing a regression, fix it at the source library level. Do not modify the caller's code to work around the issue. Always create a reliable test case that reproduces the error before implementing the fix.

--- a/test/test_tfdir_path.py
+++ b/test/test_tfdir_path.py
@@ -1,6 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import tempfile
 from pathlib import Path
 import tftest
+
 
 def test_tfdir_as_path():
   with tempfile.TemporaryDirectory() as tmpdir:
@@ -10,8 +25,8 @@ def test_tfdir_as_path():
     # if tf.tfdir is converted to a string.
     assert (tf.tfdir / 'something') == tmpdir_path / 'something'
 
+
 def test_tfdir_as_str():
   with tempfile.TemporaryDirectory() as tmpdir:
     tf = tftest.TerraformTest(tmpdir)
     assert isinstance(tf.tfdir, str)
-

--- a/test/test_tfdir_path.py
+++ b/test/test_tfdir_path.py
@@ -1,0 +1,17 @@
+import tempfile
+from pathlib import Path
+import tftest
+
+def test_tfdir_as_path():
+  with tempfile.TemporaryDirectory() as tmpdir:
+    tmpdir_path = Path(tmpdir).resolve()
+    tf = tftest.TerraformTest(tmpdir_path)
+    # The regression: tf.tfdir / 'something' throws TypeError
+    # if tf.tfdir is converted to a string.
+    assert (tf.tfdir / 'something') == tmpdir_path / 'something'
+
+def test_tfdir_as_str():
+  with tempfile.TemporaryDirectory() as tmpdir:
+    tf = tftest.TerraformTest(tmpdir)
+    assert isinstance(tf.tfdir, str)
+

--- a/tftest.py
+++ b/tftest.py
@@ -349,7 +349,7 @@ class TerraformTest(object):
     """Make relative path absolute from base dir."""
     path_obj = Path(path)
     if path_obj.is_absolute():
-      return str(path_obj)
+      return path
     return str(Path(self._basedir) / path)
 
   def _dirhash(self, directory, hash, ignore_hidden=False,
@@ -429,7 +429,7 @@ class TerraformTest(object):
         return func(self, **kwargs)
 
       cache_dir = self.cache_dir / \
-          Path(sha1(self.tfdir.encode("cp037")).hexdigest()) / \
+          Path(sha1(str(self.tfdir).encode("cp037")).hexdigest()) / \
           Path(func.__name__)
       cache_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Fixes a regression introduced during the recent Python modernization in , where  started casting the  variable to a string, effectively breaking downstream users (like ) that expect the  object to be preserved so they can use the  operator against .

This PR:
- Reverts  to return the original object when an absolute  is passed to .
- Casts  to a string before encoding it for hashing to prevent an  when  is enabled.
- Adds test coverage to prevent future regressions.
- Adds a GEMINI.md file with basic rules for agents work in this repository.