### PR TITLE
Fix TypeError when calling decorated methods with positional arguments

### DIFF
--- a/tftest.py
+++ b/tftest.py
@@ -36,7 +36,7 @@ from hashlib import sha1
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-__version__ = '1.8.6'
+__version__ = '1.8.7'
 
 _LOGGER = logging.getLogger('tftest')
 


### PR DESCRIPTION
### Description
Calling decorated methods (such as `output()`) with positional arguments resulted in a `TypeError` (e.g., `TypeError: TerraformTest._cache.<locals>.cache() takes 1 positional argument but 2 were given`). This occurred because the `_cache` decorator's wrapper was defined to only accept `self` and `**kwargs`.

This PR fixes the issue by updating the decorator to:
1.  Accept both `*args` and `**kwargs`.
2.  Use `inspect.signature` to dynamically bind the arguments to the target function's signature. This ensures positional arguments are correctly mapped to their parameter names.
3.  Remove the `self` argument from the bound arguments before hashing to prevent the object's memory address from invalidating the cache.
4.  Maintain the early short-circuit when caching is disabled globally.

### Tests
*   Added `test_output_positional_arg` to `test/test_cache.py` to verify that calling `output()` with positional arguments works correctly when caching is enabled.

### Related Issues
*   Fixes #92
